### PR TITLE
fix: primary key and data migration on schema updates

### DIFF
--- a/dat.a/lib.js
+++ b/dat.a/lib.js
@@ -1721,7 +1721,7 @@ function saveSchema() {
 
         schema.push({
             primaryKey: isPrimaryKey,
-            autoInc: title===autoIncrement,
+            autoInc: type === 'Ціле число' && isPrimaryKey,
             title: title,
             type: type,
             comment: comment,
@@ -1824,16 +1824,20 @@ function saveSchema() {
     oldData.forEach(record => {
         const insertFields = [];
         const insertValues = [];
+        const placeholders = [];
+
         for (const key of newFieldNames) {
             if (key in record) {
                 insertFields.push(`"${key}"`);
-                insertValues.push(JSON.stringify(record[key]));
+                placeholders.push('?');
+                insertValues.push(record[key] ?? null);
             }
         }
+
         if (insertFields.length > 0) {
-            const insertSQL = `INSERT INTO "${newTableName}" (${insertFields.join(", ")}) VALUES (${insertValues.join(", ")});`;
+            const insertSQL = `INSERT INTO "${newTableName}" (${insertFields.join(", ")}) VALUES (${placeholders.join(", ")});`;
             try {
-                db.run(insertSQL);
+                db.run(insertSQL, insertValues);
             } catch (e) {
                 console.warn("Не вдалося вставити запис:", e, insertSQL);
             }


### PR DESCRIPTION
Цей PR виправляє баги, зазначені у https://github.com/ed-info/ed-info.github.io/issues/70

- невірне визначення autoInc при оновленні схеми
- ненадійний імпорт старих даних до оновленної таблиці після зміни схеми (у моєму випадку проблема була з екранізацією спеціальних символів - лапок, використаних у якості символа дюймів) - правильніше використовувати параметризовані запити до БД. 