### PR TITLE
Fix/assets gallery errors

### DIFF
--- a/pgz/lib/assets-gallery.js
+++ b/pgz/lib/assets-gallery.js
@@ -165,7 +165,8 @@ async function importSelectedImage() {
   }
 }
 async function initFS() {
-  if (!fs) fs = new FileSystem("PGZfs");
+  if (!fs) fs = window.jsfs || new FileSystem("PGZfs");
+  window.jsfs = fs;
   await fs.mkdir('/images');
   await fs.mkdir('/sounds');
   await fs.mkdir('/music');

--- a/pgz/lib/assets-gallery.js
+++ b/pgz/lib/assets-gallery.js
@@ -165,10 +165,10 @@ async function importSelectedImage() {
   }
 }
 async function initFS() {
-  fs = new FileSystem("PGZfs");
+  if (!fs) fs = new FileSystem("PGZfs");
   await fs.mkdir('/images');
   await fs.mkdir('/sounds');
-  await fs.mkdir('/music'); 
+  await fs.mkdir('/music');
 }
 
 async function refreshGallery() {
@@ -527,6 +527,7 @@ async function deleteSelected(type) {
 
 // --- ЕКСПОРТ У ZIP ---
 async function exportGallery() {
+  if (!fs) await initFS();
   const zip = new JSZip();
 
   // Зображення
@@ -680,7 +681,7 @@ async function clearProjectResources() {
 async function initializeAssetsGallery() {
   await initFS();
   await refreshGallery();
-  enableDragAndDrop(); // ✅ Вмикаємо drag-and-drop
+  enableDragAndDrop();
 }
 async function importGallery() {
     const input = document.createElement('input');

--- a/pgz/lib/jsfs2.js
+++ b/pgz/lib/jsfs2.js
@@ -198,7 +198,7 @@ _Class.prototype._joinPath = function (pathArray) {
     const fs = await this._loadMetadata();
     const pathArray = this.separate(folder);
     const target = this._walkPath(fs, pathArray);
-    if (!target) throw new Error('Invalid folder');
+    if (!target) return [];
 
     const entries = Object.keys(target).sort();
     const folders = entries.filter(e => !Array.isArray(target[e]));


### PR DESCRIPTION
 Виправлення помилок `Invalid folder` та `Cannot read properties of undefined` в галереї ресурсів

  **Проблеми**
  - `Error: Invalid folder` при запуску програми або відкритті вкладок аудіо/музики в галереї
  - `TypeError: Cannot read properties of undefined (reading 'ls')` при експорті галереї

  **Причини**
  - `lib.js` і `pgzrun` створювали `window.jsfs` без ініціалізації стандартних тек (`/images`, `/sounds`, `/music`), тому `ls()` кидала виняток
  - `initFS()` у галереї створював окремий екземпляр `FileSystem`, не пов'язаний з `window.jsfs`
  - Дублікат оголошення `initializeAssetsGallery` — друге перекривало перше, втрачаючи `enableDragAndDrop()`

  **Виправлення**
  - `ls()` тепер повертає `[]` замість винятку для неіснуючих тек
  - `initFS()` синхронізує `fs` з `window.jsfs` (перевикористовує наявний екземпляр)
  - Видалено дублікат `initializeAssetsGallery`
  - Додано захист `if (!fs) await initFS()` на початку `exportGallery`