### PR TITLE
Fix fs-undefined error when importing asset with gallery closed

### DIFF
--- a/pgz/lib/assets-gallery.js
+++ b/pgz/lib/assets-gallery.js
@@ -130,6 +130,7 @@ async function importSelectedImage() {
   if (!selectedExternalImage) return;
 
   try {
+    await initFS();
     // Завантажуємо зображення як Blob
     const response = await fetch(selectedExternalImage);
     if (!response.ok) throw new Error('Не вдалося завантажити зображення');


### PR DESCRIPTION
При спробі імпортувати ресурс зі списку доступних без попереднього відкриття галереї виникала помилка `TypeError: Cannot read properties of undefined (reading 'type')` — `fs` був `undefined`, оскільки `initFS()` ще не викликався. Додано `await initFS()` на початку функції `importSelectedImage`, щоб файлова система ініціалізувалась незалежно від того, чи була галерея відкрита раніше.