### PR TITLE
Fix stop(): avoid page reload when game runs in modal

### DIFF
--- a/pgz/lib/lib.js
+++ b/pgz/lib/lib.js
@@ -1229,23 +1229,55 @@ handleError: function(err) {
     
 stop: function() {
     console.log("Stop");
-    
-    // Зберігаємо поточний код перед перезавантаженням
-    if (PythonIDE.hash && PythonIDE.aT[PythonIDE.hash]) {
-        // Зберігаємо файли для відновлення після перезавантаження
-        PythonIDE.aT[PythonIDE.hash].c = JSON.parse(JSON.stringify(PythonIDE.files));
-        PythonIDE.aT[PythonIDE.hash].t = Date.now();
-        localStorage.aT = JSON.stringify(PythonIDE.aT);
+
+    // Якщо запущено через URL /run/ — потрібен reload для зміни URL
+    if (window.location.href.indexOf('/run/') > -1) {
+        if (PythonIDE.hash && PythonIDE.aT[PythonIDE.hash]) {
+            PythonIDE.aT[PythonIDE.hash].c = JSON.parse(JSON.stringify(PythonIDE.files));
+            PythonIDE.aT[PythonIDE.hash].t = Date.now();
+            localStorage.aT = JSON.stringify(PythonIDE.aT);
+        }
+        localStorage.loadAction = "restoreCode";
+        window.location = window.location.href
+            .replace('run/', 'python/')
+            .replace('?run', '');
+        return;
     }
-    
-    // Встановлюємо прапорець для відновлення коду після перезавантаження
-    localStorage.loadAction = "restoreCode";
-    
-    // Змінюємо URL і перезавантажуємо
-    window.location = window.location.href
-        .replace('run/', 'python/')
-        .replace('?run', '');
-    location.reload();
+
+    // Зупиняємо game loop pgzrun
+    window.PGZ_STOP_REQUESTED = true;
+
+    // Ховаємо вікно гри та геймпад
+    const gameModal = document.getElementById('gameModal');
+    if (gameModal) gameModal.style.display = 'none';
+    const gamepad = document.getElementById('virtual-gamepad');
+    if (gamepad) gamepad.style.display = 'none';
+
+    // Скидаємо кнопки UI
+    const btnStop = document.getElementById('btn_stopRunning');
+    const btnRun = document.getElementById('btn_run');
+    if (btnStop) { btnStop.style.display = 'none'; btnStop.classList.remove('visibleButton'); }
+    if (btnRun) btnRun.style.display = 'block';
+
+    // Скидаємо стан Skulpt/IDE
+    PythonIDE.running = false;
+    PythonIDE.runMode = 'finished';
+    PythonIDE.continueRunning = false;
+    if (PythonIDE.continueDebug) delete PythonIDE.continueDebug;
+    if (PythonIDE.abortDebug) delete PythonIDE.abortDebug;
+
+    // Клонуємо canvas щоб зняти всі event listeners
+    const canvas = document.getElementById('gameCanvas');
+    if (canvas && canvas.parentNode) {
+        const newCanvas = canvas.cloneNode(false);
+        canvas.parentNode.replaceChild(newCanvas, canvas);
+    }
+
+    // Скидаємо прапорець і оновлюємо редактор
+    setTimeout(function() {
+        window.PGZ_STOP_REQUESTED = false;
+        PythonIDE.editor.refresh();
+    }, 100);
 },
     
     keyHandlers: [],
@@ -1801,6 +1833,7 @@ if(localStorage.loadAction === "restoreCode") {
             PythonIDE.editor.setValue(PythonIDE.files[PythonIDE.currentFile]);
             PythonIDE.updateFileTabs();
             PythonIDE.editor.focus();
+            setTimeout(function() { PythonIDE.editor.refresh(); }, 0);
  /*
             PythonIDE.showHint(selectedLang === 'en' 
                 ? "Showing the code you last edited " + timeSince(PythonIDE.aT[PythonIDE.hash].t) + " ago" 

--- a/pgz/lib/skulpt/pgzrun/__init__.js
+++ b/pgz/lib/skulpt/pgzrun/__init__.js
@@ -3634,7 +3634,10 @@ Sk.globals.clock = Sk.misceval.callsim(Clock);
             if (Sk.globals.draw) {
                 tasks.push(Sk.misceval.callsimAsync(handlers, Sk.globals.draw));
             }
-            return Promise.all(tasks).then(() => window.requestAnimationFrame(update)).catch(PythonIDE.handleError);
+            return Promise.all(tasks).then(() => {
+                if (window.PGZ_STOP_REQUESTED) return;
+                window.requestAnimationFrame(update);
+            }).catch(PythonIDE.handleError);
         }
         // add event handlers
         // Універсальна функція для отримання координат


### PR DESCRIPTION
**Проблема**

  При закритті вікна гри (кнопка ×) викликався `location.reload()`, що призводило до двох проблем:
  - непотрібне повне перезавантаження сторінки при кожній зупинці гри
  - код у редакторі зникав після перезавантаження і з'являвся лише після кліку на редактор або повторного натискання СТОП (CodeMirror не отримував `refresh()`)

  **Рішення**

  `lib/lib.js` — `stop()` тепер поділений на два шляхи:
  - якщо URL містить `/run/` — залишається старий `reload` (він там дійсно потрібен для зміни URL)
  - в усіх інших випадках (гра в modal) — зупинка без reload: ховається `gameModal`, скидається стан IDE, canvas клонується (знімаються всі event listeners), викликається `editor.refresh()`

  `lib/skulpt/pgzrun/__init__.js` — в `update()` додано перевірку прапорця `window.PGZ_STOP_REQUESTED` перед наступним `requestAnimationFrame`, що дозволяє чисто зупинити game loop